### PR TITLE
Descripción del proyecto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # CCSS
 Proyecto Universidad Fidelitas: Sistema Indicador de Riesgo Bucodental (SIRB) de la CCSS
+Descripción del proyecto
+El sistema de Riesgo Bucodental (SIRB), es un instrumento de screening, para detectar el riego de padecer enfermedades bucodentales. Estos son métodos de análisis simples que se utilizan para la identificación o el descarte de patologías en pacientes, los cuales son aplicados para obtener una información rápida sobre esas patologías.


### PR DESCRIPTION

El sistema de Riesgo Bucodental (SIRB), es un instrumento de screening, para detectar el riego de padecer enfermedades bucodentales. Estos son métodos de análisis simples que se utilizan para la identificación o el descarte de patologías en pacientes, los cuales son aplicados para obtener una información rápida sobre esas patologías.